### PR TITLE
unnecessary `list` call - write as literal

### DIFF
--- a/edualgo/algorithms/sort.py
+++ b/edualgo/algorithms/sort.py
@@ -320,7 +320,7 @@ def insertion_sort_hint():
     print_msg_box(message)
 
 def merge_sorted_lists(l1, l2):
-    arr=list()
+    arr=[]
     i=j=0
     while i < len(l1) or j < len(l2):
         if j >= len(l2):


### PR DESCRIPTION
In [5]: timeit.timeit(stmt="list()", number=100000000)
Out[5]: 7.356000728000254

In [6]: timeit.timeit(stmt="[]", number=100000000)
Out[6]: 1.573771306999788